### PR TITLE
Add reward module for emulator integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # PokeYellowAI
+
+Utilities for training reinforcement learning agents on **Pokémon Yellow**.
+
+This repository ships a ROM (`PokemonYellow.gbc`) and helper Python code for
+connecting to a Gym Retro compatible emulator.
+
+## Reward Helpers
+
+The `reward.py` module exposes functions to:
+
+* Connect to a Game Boy emulator via Gym Retro.
+* Read bytes from important WRAM addresses.
+* Evaluate training goals defined in a JSON specification.
+
+A sample goal file is provided in `first_two_gyms.json`.
+
+### Example
+
+```python
+import reward
+
+# Create the Retro environment. The game must be registered with Gym Retro.
+env = reward.connect_emulator("PokemonYellow-GB")
+
+# Load goal predicates
+spec = reward.load_goal_spec("first_two_gyms.json")
+
+observation = env.reset()
+for step in range(1000):
+    # Replace with your own policy or training algorithm
+    action = env.action_space.sample()
+    observation, _reward, done, _info = env.step(action)
+
+    ram = reward.read_wram_bytes(env)
+    status = reward.evaluate_goals(ram, spec)
+    if status[0]["met"]:
+        print("First gym reached!")
+        break
+
+    if done:
+        observation = env.reset()
+```

--- a/first_two_gyms.json
+++ b/first_two_gyms.json
@@ -1,0 +1,16 @@
+{
+  "goals": [
+    {
+      "description": "Reach Pewter Gym (Brock)",
+      "predicates": [
+        {"address": "0xD35D", "equals": 1}
+      ]
+    },
+    {
+      "description": "Reach Cerulean Gym (Misty)",
+      "predicates": [
+        {"address": "0xD355", "equals": 2}
+      ]
+    }
+  ]
+}

--- a/reward.py
+++ b/reward.py
@@ -1,0 +1,67 @@
+import json
+from typing import Any, Dict, List
+
+import retro
+
+# WRAM addresses used for tracking progress. These are specific to
+# Pokemon Yellow and may need to be adjusted for other ROMs.
+WRAM_ADDRESSES = [0xD35D, 0xD355, 0xD754, 0xD75D]
+
+
+def connect_emulator(game_name: str, state: str | None = None) -> retro.RetroEnv:
+    """Return a Gym Retro environment for the given game name.
+
+    Parameters
+    ----------
+    game_name: str
+        The identifier of the Gym Retro game. The ROM must be installed and
+        registered with Gym Retro.
+    state: str | None, optional
+        Optional saved state to load when starting the environment.
+    """
+    env = retro.make(game=game_name, state=state)
+    return env
+
+
+def read_wram_bytes(env: retro.RetroEnv) -> Dict[int, int]:
+    """Read bytes from the emulator's WRAM at predefined addresses."""
+    ram_snapshot = {}
+    for address in WRAM_ADDRESSES:
+        value = env.get_memory(address, 1)[0]
+        ram_snapshot[address] = value
+    return ram_snapshot
+
+
+def load_goal_spec(path: str) -> Dict[str, Any]:
+    """Load a goal specification from a JSON file."""
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def evaluate_goals(ram_snapshot: Dict[int, int], spec: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Evaluate goal predicates defined in the specification.
+
+    Parameters
+    ----------
+    ram_snapshot: Dict[int, int]
+        Mapping of WRAM addresses to the current byte value at that address.
+    spec: Dict[str, Any]
+        Goal specification loaded from ``load_goal_spec``.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        A list of dictionaries describing whether each goal has been met.
+    """
+    results = []
+    for goal in spec.get("goals", []):
+        predicates = goal.get("predicates", [])
+        met = True
+        for pred in predicates:
+            address = int(pred["address"], 16)
+            expected = int(pred["equals"], 0)
+            if ram_snapshot.get(address) != expected:
+                met = False
+                break
+        results.append({"description": goal.get("description", ""), "met": met})
+    return results


### PR DESCRIPTION
## Summary
- add `reward.py` with helpers for Gym Retro integration
- provide sample goal file `first_two_gyms.json`
- expand README with usage example

## Testing
- `python3 -m py_compile reward.py`