### PR TITLE
Add gym training example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # PokeYellowAI
+
+This repository contains resources for training reinforcement learning agents on Pokémon Yellow using Gym Retro.
+
+See [examples/train_first_two_gyms.py](examples/train_first_two_gyms.py) for a basic example that demonstrates loading the ROM, computing rewards with ``rewards.compute_reward``, and logging milestone completions.

--- a/examples/train_first_two_gyms.py
+++ b/examples/train_first_two_gyms.py
@@ -1,0 +1,46 @@
+"""Example script to train up to the first two gyms using gym-retro."""
+
+import logging
+import random
+
+import retro
+
+from rewards import compute_reward
+
+
+# Map IDs from the disassembly are required to detect milestone completion.
+# Replace the placeholders below with the actual values once known.
+PEWTER_CITY_MAP_ID = 0  # TODO: insert real map ID for Pewter City
+CERULEAN_CITY_MAP_ID = 0  # TODO: insert real map ID for Cerulean City
+
+
+def main():
+    """Runs a basic loop over the ROM and logs when gym milestones are reached."""
+    logging.basicConfig(level=logging.INFO)
+
+    env = retro.make(game='PokemonYellow', rom_path='PokemonYellow.gbc')
+    obs = env.reset()
+
+    done = False
+    total_reward = 0.0
+
+    while not done:
+        # Random policy for demonstration purposes.
+        action = env.action_space.sample()
+        obs, reward, done, info = env.step(action)
+
+        total_reward += compute_reward(info)
+
+        current_map = info.get('map_id')
+        if current_map == PEWTER_CITY_MAP_ID:
+            logging.info('Reached Pewter City (Gym 1).')
+        elif current_map == CERULEAN_CITY_MAP_ID:
+            logging.info('Reached Cerulean City (Gym 2).')
+            break  # Stop after the second gym
+
+    env.close()
+    logging.info('Total reward: %s', total_reward)
+
+
+if __name__ == '__main__':
+    main()

--- a/rewards.py
+++ b/rewards.py
@@ -1,0 +1,22 @@
+"""Simple reward computation for PokeYellow gym training.
+
+This module exposes ``compute_reward`` which inspects info dictionaries from
+Gym Retro and computes a numeric reward. Adjust the logic as needed.
+"""
+
+from typing import Any, Dict
+
+
+def compute_reward(info: Dict[str, Any]) -> float:
+    """Return a basic reward based on the environment info dict.
+
+    Parameters
+    ----------
+    info: dict
+        The info dictionary returned by ``env.step`` in Gym Retro. It is
+        expected to contain at least ``score``. You can extend this function
+        to incorporate more sophisticated signals as desired.
+    """
+    # Default reward uses the score field if present; otherwise zero.
+    return float(info.get('score', 0))
+


### PR DESCRIPTION
## Summary
- add a simple reward module
- add `train_first_two_gyms.py` example demonstrating Gym Retro usage
- mention the example script in README

## Testing
- `python -m py_compile examples/train_first_two_gyms.py rewards.py`