### PR TITLE
Fix map ID address and update tests

### DIFF
--- a/poke_rewards.py
+++ b/poke_rewards.py
@@ -3,7 +3,8 @@
 from typing import Dict, Iterable, List, Tuple
 
 # Memory addresses based on community documentation
-MAP_ID_ADDR = 0xD35E
+# Address of the current map ID within WRAM
+MAP_ID_ADDR = 0xD35D
 BADGE_FLAGS_ADDR = 0xD356
 EVENT_FLAGS_BASE = 0xD747
 

--- a/tests/test_poke_rewards.py
+++ b/tests/test_poke_rewards.py
@@ -11,6 +11,10 @@ def make_mem(map_id: int = 0, badge_flags: int = 0, size: int = 0xE000) -> bytea
 
 
 class TestPokeRewards(unittest.TestCase):
+    def test_map_id_address_constant(self):
+        """Ensure MAP_ID_ADDR matches the documented location."""
+        self.assertEqual(MAP_ID_ADDR, 0xD35D)
+
     def test_map_transition_triggers_goal(self):
         prev = make_mem(map_id=0)
         curr = make_mem(map_id=1)


### PR DESCRIPTION
## Summary
- correct MAP_ID_ADDR to 0xD35D
- verify address constant in tests

## Testing
- `PYTHONPATH=. python -m unittest discover -s tests -v`