### PR TITLE
Fix gather_rollout obs reset

### DIFF
--- a/tests/test_rollout_shapes.py
+++ b/tests/test_rollout_shapes.py
@@ -44,6 +44,22 @@ class TestRolloutShapes(unittest.TestCase):
         self.assertEqual(len(rollout["states"]), 1)
         self.assertEqual(rollout["states"][0].shape, torch.Size(obs_shape))
 
+    def test_obs_reset_after_done(self):
+        """New observation from env.reset() should be used after episode end."""
+        env = DummyEnv()
+        obs_space_shape = env.observation_space.shape
+        obs_shape = (obs_space_shape[2], obs_space_shape[0], obs_space_shape[1])
+        model = ActorCritic(obs_shape, env.action_space.n)
+        curriculum = Curriculum([])
+
+        rollout = gather_rollout(env, model, curriculum, rollout_steps=2)
+        self.assertEqual(len(rollout["states"]), 2)
+        first_state = rollout["states"][0].numpy()
+        second_state = rollout["states"][1].numpy()
+
+        self.assertTrue(np.all(first_state == 0))
+        self.assertTrue(np.all(second_state == 0))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/train_agent.py
+++ b/train_agent.py
@@ -153,14 +153,14 @@ def gather_rollout(env: retro.RetroEnv, model: ActorCritic, curriculum: Curricul
         storage["rewards"].append(shaped)
         storage["dones"].append(done)
 
-        obs = next_obs
-        prev_mem = curr_mem
-
         if done:
-            env.reset()
+            obs = env.reset()
             prev_mem = env.get_ram()
             curriculum.record_episode(episode_goals)
             episode_goals = set()
+        else:
+            obs = next_obs
+            prev_mem = curr_mem
 
     return storage
 


### PR DESCRIPTION
## Summary
- fix resetting observation when an episode ends
- use the reset observation for the next step
- test that gather_rollout uses reset observation

## Testing
- `python -m unittest`