### PR TITLE
Use Gym Retro integration for Pokémon Yellow

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,23 @@ Rewards are produced by comparing consecutive WRAM snapshots.  Goals can trigger
 
 ## Training
 
-Training uses a small PPO implementation found in `train_agent.py`.  Launch it with:
+Training uses a small PPO implementation found in `train_agent.py`.
+
+First register the ROM with Gym Retro using the `retro.import` utility:
 
 ```bash
-python train_agent.py --rom PokemonYellow.gbc --goals data/first_three_gyms.json
+python -m retro.import PokemonYellow.gbc --output integrations
 ```
 
-You may supply a different goals file using `--goals`.  During training, goals are unlocked gradually according to their prerequisites, forming a simple curriculum.
+This creates `integrations/PokemonYellow-GB` containing the ROM and metadata.
+You can then start training with:
+
+```bash
+python train_agent.py --retro-dir integrations --goals data/first_three_gyms.json
+```
+
+If you already imported the ROM into `~/.retro`, the `--retro-dir` argument can
+be omitted. You may supply a different goals file using `--goals`. During
+training, goals are unlocked gradually according to their prerequisites, forming
+a simple curriculum.
 

--- a/train_agent.py
+++ b/train_agent.py
@@ -202,13 +202,18 @@ def ppo_update(model: ActorCritic, optimizer: optim.Optimizer, rollout: Dict[str
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train a PPO agent on Pokémon Yellow")
-    parser.add_argument("--rom", default="PokemonYellow.gbc", help="Path to the Pokémon Yellow ROM")
+    parser.add_argument(
+        "--retro-dir",
+        default="integrations",
+        help="Path to a Gym Retro integration directory containing Pokemon Yellow",
+    )
     parser.add_argument("--goals", default="data/first_three_gyms.json", help="JSON file describing goal curriculum")
     parser.add_argument("--total-steps", type=int, default=100000, help="Total environment steps to train")
     parser.add_argument("--rollout-steps", type=int, default=2048, help="Number of steps per PPO rollout")
     args = parser.parse_args()
 
-    env = retro.make(game=args.rom)
+    retro.data.Integrations.add_custom_path(args.retro_dir)
+    env = retro.make(game="PokemonYellow-GB")
     obs_space_shape = env.observation_space.shape
     obs_shape = (obs_space_shape[2], obs_space_shape[0], obs_space_shape[1])
     n_actions = env.action_space.n


### PR DESCRIPTION
## Summary
- support custom Gym Retro integration directory for Pokemon Yellow
- update PPO training loop to register integration and open `PokemonYellow-GB`
- explain ROM import and training command in README

## Testing
- `python -m py_compile train_agent.py`
