### PR TITLE
Simplify reward API

### DIFF
--- a/poke_rewards.py
+++ b/poke_rewards.py
@@ -37,8 +37,6 @@ def check_goals(
     prev_mem: bytes,
     curr_mem: bytes,
     goals: Iterable[Goal],
-    map_ids: Dict[str, int],
-    flags: Dict[str, int],
 ) -> List[Tuple[str, float]]:
     """Check memory snapshots for goal completion.
 
@@ -50,13 +48,6 @@ def check_goals(
         Iterable of goal dictionaries.  Each goal must contain ``id`` (str),
         ``type`` (``"map"`` or ``"event"``), and ``target_id`` (int).  Goals may
         optionally include ``reward`` (float).
-    map_ids
-        Mapping of map names to their numeric identifiers.  Currently used only
-        for reference.
-    flags
-        Mapping of event flag descriptions to their memory offsets.  Currently
-        used only when ``type`` is ``"event"`` and the target refers to a generic
-        flag rather than badge flags.
 
     Returns
     -------

--- a/tests/test_poke_rewards.py
+++ b/tests/test_poke_rewards.py
@@ -23,7 +23,7 @@ class TestPokeRewards(unittest.TestCase):
             {"id": "reach_viridian_city", "type": "map", "target_id": 1, "reward": 1.0}
         ]
 
-        triggered = check_goals(prev, curr, goals, {}, {})
+        triggered = check_goals(prev, curr, goals)
         self.assertEqual(triggered, [("reach_viridian_city", 1.0)])
 
     def test_event_flag_triggers_goal(self):
@@ -34,7 +34,7 @@ class TestPokeRewards(unittest.TestCase):
             {"id": "defeat_brock", "type": "event", "target_id": 0, "reward": 5.0}
         ]
 
-        triggered = check_goals(prev, curr, goals, {}, {})
+        triggered = check_goals(prev, curr, goals)
         self.assertEqual(triggered, [("defeat_brock", 5.0)])
 
     def test_no_trigger_when_values_unchanged(self):
@@ -46,7 +46,7 @@ class TestPokeRewards(unittest.TestCase):
             {"id": "defeat_brock", "type": "event", "target_id": 0, "reward": 5.0},
         ]
 
-        triggered = check_goals(prev, curr, goals, {}, {})
+        triggered = check_goals(prev, curr, goals)
         self.assertEqual(triggered, [])
 
     def test_multiple_goals_same_frame(self):
@@ -58,7 +58,7 @@ class TestPokeRewards(unittest.TestCase):
             {"id": "defeat_brock", "type": "event", "target_id": 0, "reward": 5.0},
         ]
 
-        triggered = check_goals(prev, curr, goals, {}, {})
+        triggered = check_goals(prev, curr, goals)
         self.assertEqual(sorted(triggered), [
             ("defeat_brock", 5.0),
             ("reach_viridian_city", 1.0),

--- a/train_agent.py
+++ b/train_agent.py
@@ -141,7 +141,7 @@ def gather_rollout(env: retro.RetroEnv, model: ActorCritic, curriculum: Curricul
         action, log_p, value = model.act(obs)
         next_obs, reward, done, _info = env.step(action)
         curr_mem = env.get_ram()
-        triggered = check_goals(prev_mem, curr_mem, curriculum.active_goals(), {}, {})
+        triggered = check_goals(prev_mem, curr_mem, curriculum.active_goals())
         shaped = reward + sum(r for _g, r in triggered)
         episode_goals.update(g for g, _r in triggered)
 


### PR DESCRIPTION
## Summary
- drop unused `map_ids` and `flags` parameters from `check_goals`
- update reward tests for new signature
- adjust `train_agent.gather_rollout` to match

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m pytest -q` *(fails: No module named pytest)*