### PR TITLE
Add rewarder utilities and tests

### DIFF
--- a/rewarder.py
+++ b/rewarder.py
@@ -1,0 +1,60 @@
+"""Goal-based reward computation utilities."""
+
+from typing import Callable, Dict, Iterable, List, Tuple
+
+from poke_rewards import (
+    _map_changed,
+    _badge_bit_set,
+    _event_flag_set,
+)
+
+
+
+Goal = Dict[str, object]
+Predicate = Callable[[bytes, bytes], bool]
+
+
+def predicate_from_goal(goal: Goal) -> Predicate:
+    """Create a predicate function for a single goal."""
+    gtype = goal.get("type")
+    target_id = int(goal.get("target_id", 0))
+
+    if gtype == "map":
+        def pred(prev: bytes, curr: bytes) -> bool:
+            changed, curr_map = _map_changed(prev, curr)
+            return changed and curr_map == target_id
+        return pred
+    elif gtype == "event":
+        if target_id < 8:
+            def pred(prev: bytes, curr: bytes) -> bool:
+                return _badge_bit_set(prev, curr, target_id)
+            return pred
+        else:
+            def pred(prev: bytes, curr: bytes) -> bool:
+                return _event_flag_set(prev, curr, target_id - 8)
+            return pred
+    else:
+        raise ValueError(f"Unknown goal type: {gtype}")
+
+
+class Rewarder:
+    """Compute shaped rewards from WRAM snapshots."""
+
+    def __init__(self, goals: Iterable[Goal]):
+        self._entries: List[Tuple[str, Predicate, float]] = []
+        for goal in goals:
+            pred = predicate_from_goal(goal)
+            reward = float(goal.get("reward", 1.0))
+            self._entries.append((goal["id"], pred, reward))
+
+    def compute(
+        self, prev_mem: bytes, curr_mem: bytes, env_reward: float = 0.0
+    ) -> Tuple[float, List[str]]:
+        """Return total reward and IDs of triggered goals."""
+        total = env_reward
+        triggered: List[str] = []
+        for gid, pred, reward in self._entries:
+            if pred(prev_mem, curr_mem):
+                triggered.append(gid)
+                total += reward
+        return total, triggered

--- a/tests/test_rewarder.py
+++ b/tests/test_rewarder.py
@@ -1,0 +1,44 @@
+import pytest
+
+from rewarder import predicate_from_goal, Rewarder
+from poke_rewards import MAP_ID_ADDR, BADGE_FLAGS_ADDR
+
+
+def make_mem(map_id: int = 0, badge_flags: int = 0, size: int = 0xE000) -> bytearray:
+    mem = bytearray(size)
+    mem[MAP_ID_ADDR] = map_id
+    mem[BADGE_FLAGS_ADDR] = badge_flags
+    return mem
+
+
+class TestPredicateFromGoal:
+    def test_map_goal_predicate(self):
+        goal = {"id": "reach_city", "type": "map", "target_id": 1}
+        pred = predicate_from_goal(goal)
+        prev = make_mem(map_id=0)
+        curr = make_mem(map_id=1)
+        assert pred(prev, curr) is True
+        # no change should be False
+        assert not pred(curr, curr)
+
+    def test_event_goal_predicate(self):
+        goal = {"id": "defeat_brock", "type": "event", "target_id": 0}
+        pred = predicate_from_goal(goal)
+        prev = make_mem(badge_flags=0)
+        curr = make_mem(badge_flags=0b00000001)
+        assert pred(prev, curr) is True
+        assert not pred(curr, curr)
+
+
+class TestRewarderCompute:
+    def test_compute_returns_sum_and_ids(self):
+        goals = [
+            {"id": "reach_city", "type": "map", "target_id": 1, "reward": 1.0},
+            {"id": "defeat_brock", "type": "event", "target_id": 0, "reward": 5.0},
+        ]
+        rew = Rewarder(goals)
+        prev = make_mem(map_id=0, badge_flags=0)
+        curr = make_mem(map_id=1, badge_flags=0b00000001)
+        total, triggered = rew.compute(prev, curr, env_reward=0.5)
+        assert total == pytest.approx(6.5)
+        assert set(triggered) == {"reach_city", "defeat_brock"}


### PR DESCRIPTION
## Summary
- implement `rewarder.py` with `predicate_from_goal` and `Rewarder` class
- add tests for goal predicates and Rewarder reward computation

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*