### PR TITLE
Remove unused import

### DIFF
--- a/tests/test_rollout_shapes.py
+++ b/tests/test_rollout_shapes.py
@@ -1,4 +1,3 @@
-import importlib.util
 import unittest
 
 try:


### PR DESCRIPTION
## Summary
- clean up unused import in `tests/test_rollout_shapes.py`

## Testing
- `python -m unittest discover -v tests`
