### PR TITLE
Add buffer checks in poke_rewards

### DIFF
--- a/tests/test_poke_rewards.py
+++ b/tests/test_poke_rewards.py
@@ -1,6 +1,14 @@
 import unittest
 
-from poke_rewards import check_goals, MAP_ID_ADDR, BADGE_FLAGS_ADDR
+from poke_rewards import (
+    check_goals,
+    MAP_ID_ADDR,
+    BADGE_FLAGS_ADDR,
+    EVENT_FLAGS_BASE,
+    _map_changed,
+    _badge_bit_set,
+    _event_flag_set,
+)
 
 
 def make_mem(map_id: int = 0, badge_flags: int = 0, size: int = 0xE000) -> bytearray:
@@ -63,6 +71,29 @@ class TestPokeRewards(unittest.TestCase):
             ("defeat_brock", 5.0),
             ("reach_viridian_city", 1.0),
         ])
+
+    def test_map_changed_short_buffer(self):
+        prev = bytearray(MAP_ID_ADDR)
+        curr = bytearray(MAP_ID_ADDR + 1)
+        with self.assertRaises(ValueError) as ctx:
+            _map_changed(prev, curr)
+        self.assertIn("too small", str(ctx.exception))
+
+    def test_badge_bit_set_short_buffer(self):
+        prev = bytearray(BADGE_FLAGS_ADDR)
+        curr = bytearray(BADGE_FLAGS_ADDR)
+        with self.assertRaises(ValueError) as ctx:
+            _badge_bit_set(prev, curr, 0)
+        self.assertIn("too small", str(ctx.exception))
+
+    def test_event_flag_set_short_buffer(self):
+        flag_index = 0
+        offset = EVENT_FLAGS_BASE + flag_index // 8
+        prev = bytearray(offset)
+        curr = bytearray(offset)
+        with self.assertRaises(ValueError) as ctx:
+            _event_flag_set(prev, curr, flag_index)
+        self.assertIn("too small", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_rewarder.py
+++ b/tests/test_rewarder.py
@@ -1,4 +1,4 @@
-import pytest
+import unittest
 
 from rewarder import predicate_from_goal, Rewarder
 from poke_rewards import MAP_ID_ADDR, BADGE_FLAGS_ADDR
@@ -11,26 +11,26 @@ def make_mem(map_id: int = 0, badge_flags: int = 0, size: int = 0xE000) -> bytea
     return mem
 
 
-class TestPredicateFromGoal:
+class TestPredicateFromGoal(unittest.TestCase):
     def test_map_goal_predicate(self):
         goal = {"id": "reach_city", "type": "map", "target_id": 1}
         pred = predicate_from_goal(goal)
         prev = make_mem(map_id=0)
         curr = make_mem(map_id=1)
-        assert pred(prev, curr) is True
+        self.assertTrue(pred(prev, curr))
         # no change should be False
-        assert not pred(curr, curr)
+        self.assertFalse(pred(curr, curr))
 
     def test_event_goal_predicate(self):
         goal = {"id": "defeat_brock", "type": "event", "target_id": 0}
         pred = predicate_from_goal(goal)
         prev = make_mem(badge_flags=0)
         curr = make_mem(badge_flags=0b00000001)
-        assert pred(prev, curr) is True
-        assert not pred(curr, curr)
+        self.assertTrue(pred(prev, curr))
+        self.assertFalse(pred(curr, curr))
 
 
-class TestRewarderCompute:
+class TestRewarderCompute(unittest.TestCase):
     def test_compute_returns_sum_and_ids(self):
         goals = [
             {"id": "reach_city", "type": "map", "target_id": 1, "reward": 1.0},
@@ -40,5 +40,9 @@ class TestRewarderCompute:
         prev = make_mem(map_id=0, badge_flags=0)
         curr = make_mem(map_id=1, badge_flags=0b00000001)
         total, triggered = rew.compute(prev, curr, env_reward=0.5)
-        assert total == pytest.approx(6.5)
-        assert set(triggered) == {"reach_city", "defeat_brock"}
+        self.assertAlmostEqual(total, 6.5)
+        self.assertEqual(set(triggered), {"reach_city", "defeat_brock"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate prev/curr length before reading WRAM addresses
- raise `ValueError` with descriptive messages
- rewrite rewarder tests to avoid pytest dependency
- add unit tests for short buffer errors

## Testing
- `python -m unittest discover -s tests`