### PR TITLE
Add configurable output path for trained model

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,14 @@ You can then start training with:
 python train_agent.py --retro-dir integrations \
     --goals data/first_three_gyms.json \
     --config configs/default.json
+    --output-model my_weights.pt
 ```
 
 If you already imported the ROM into `~/.retro`, the `--retro-dir` argument can
 be omitted. You may supply a different goals file using `--goals` and a
-different hyperparameter file using `--config`. During training, goals are
+different hyperparameter file using `--config`. The resulting network weights
+are saved to `ppo_pokemon_yellow.pt` by default.  Use `--output-model` to
+specify a different path. During training, goals are
 unlocked gradually according to their prerequisites, forming a simple
 curriculum.
 

--- a/tests/test_train_agent_cli.py
+++ b/tests/test_train_agent_cli.py
@@ -1,0 +1,13 @@
+import unittest
+
+
+class TestTrainAgentCLI(unittest.TestCase):
+    def test_output_model_argument_present(self):
+        with open('train_agent.py', 'r', encoding='utf-8') as f:
+            src = f.read()
+        self.assertIn('--output-model', src)
+        self.assertIn('args.output_model', src)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/train_agent.py
+++ b/train_agent.py
@@ -39,6 +39,11 @@ def main() -> None:
     )
     parser.add_argument("--total-steps", type=int, default=100000, help="Total environment steps to train")
     parser.add_argument("--rollout-steps", type=int, default=2048, help="Number of steps per PPO rollout")
+    parser.add_argument(
+        "--output-model",
+        default="ppo_pokemon_yellow.pt",
+        help="Path to save the trained model",
+    )
     args = parser.parse_args()
 
     retro.data.Integrations.add_custom_path(args.retro_dir)
@@ -84,7 +89,7 @@ def main() -> None:
         print(f"Steps: {steps} | Active goals: {len(curriculum.active_goals())}")
 
     env.close()
-    torch.save(model.state_dict(), "ppo_pokemon_yellow.pt")
+    torch.save(model.state_dict(), args.output_model)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make output model path configurable with `--output-model`
- save the model using the specified path
- document the new CLI argument in the README
- add simple unit test checking CLI option

## Testing
- `python -m unittest discover -v tests`