### PR TITLE
Refactor Goal type alias

### DIFF
--- a/poke_rewards.py
+++ b/poke_rewards.py
@@ -1,15 +1,14 @@
 """Reward detection utilities for Pokémon Yellow WRAM snapshots."""
 
-from typing import Dict, Iterable, List, Tuple
+from typing import Iterable, List, Tuple
+
+from types_shared import Goal
 
 # Memory addresses based on community documentation
 # Address of the current map ID within WRAM
 MAP_ID_ADDR = 0xD35D
 BADGE_FLAGS_ADDR = 0xD356
 EVENT_FLAGS_BASE = 0xD747
-
-
-Goal = Dict[str, object]
 
 
 def _map_changed(prev: bytes, curr: bytes) -> Tuple[bool, int]:

--- a/ppo.py
+++ b/ppo.py
@@ -12,6 +12,8 @@ import json
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Sequence, Tuple
 
+from types_shared import Goal
+
 try:
     import yaml  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
@@ -31,8 +33,6 @@ except ModuleNotFoundError:  # pragma: no cover - modules may be missing during 
     optim = None
 
 from poke_rewards import check_goals
-
-Goal = Dict[str, object]
 
 
 def load_config(path: str) -> Dict[str, Any]:

--- a/rewarder.py
+++ b/rewarder.py
@@ -1,6 +1,8 @@
 """Goal-based reward computation utilities."""
 
-from typing import Callable, Dict, Iterable, List, Tuple
+from typing import Callable, Iterable, List, Tuple
+
+from types_shared import Goal
 
 from poke_rewards import (
     _map_changed,
@@ -9,8 +11,6 @@ from poke_rewards import (
 )
 
 
-
-Goal = Dict[str, object]
 Predicate = Callable[[bytes, bytes], bool]
 
 

--- a/types_shared.py
+++ b/types_shared.py
@@ -1,0 +1,6 @@
+"""Common type aliases for PokeYellowAI modules."""
+
+from typing import Dict
+
+# Mapping of goal attributes used across the project
+Goal = Dict[str, object]


### PR DESCRIPTION
## Summary
- create `types_shared.py` for common Goal alias
- import `Goal` from the shared module in main sources

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*