### PR TITLE
Add logging to training and data scripts

### DIFF
--- a/scripts/extract_static_data.py
+++ b/scripts/extract_static_data.py
@@ -1,8 +1,11 @@
 import json
+import logging
 import os
 import re
 from html.parser import HTMLParser
 from typing import Dict, List
+
+logger = logging.getLogger(__name__)
 
 
 class EventFlagHTMLParser(HTMLParser):
@@ -45,7 +48,7 @@ def parse_map_constants(path: str, prefix: str) -> Dict[str, int]:
     """Parse assembly constant definitions starting with a given prefix."""
     constants: Dict[str, int] = {}
     if not os.path.exists(path):
-        print(f"Warning: {path} not found. Skipping.")
+        logger.warning("%s not found. Skipping.", path)
         return constants
 
     pattern = re.compile(rf"^\s*{prefix}([A-Z0-9_]+)\s+EQU\s+\$?([0-9A-Fa-f]+)")
@@ -78,7 +81,7 @@ def parse_event_flags(path: str) -> Dict[str, int]:
 
     flags: Dict[str, int] = {}
     if not os.path.exists(path):
-        print(f"Warning: {path} not found. Event flags not extracted.")
+        logger.warning("%s not found. Event flags not extracted.", path)
         return flags
 
     if path.endswith(".html"):
@@ -108,6 +111,7 @@ def parse_event_flags(path: str) -> Dict[str, int]:
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO)
     os.makedirs("data", exist_ok=True)
 
     map_ids = parse_maps("maps.asm")

--- a/train_agent.py
+++ b/train_agent.py
@@ -8,6 +8,7 @@ unlocked gradually using a simple curriculum strategy.
 
 import argparse
 import json
+import logging
 import random
 
 import retro
@@ -24,8 +25,12 @@ from ppo import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description="Train a PPO agent on Pokémon Yellow")
     parser.add_argument(
         "--retro-dir",
@@ -104,7 +109,11 @@ def main() -> None:
             gamma=gamma,
             lam=lam,
         )
-        print(f"Steps: {steps} | Active goals: {len(curriculum.active_goals())}")
+        logger.info(
+            "Steps: %s | Active goals: %s",
+            steps,
+            len(curriculum.active_goals()),
+        )
 
     env.close()
     torch.save(model.state_dict(), args.output_model)


### PR DESCRIPTION
## Summary
- configure basic loggers for train_agent.py and extract_static_data.py
- swap print statements for logger calls

## Testing
- `python -m py_compile train_agent.py scripts/extract_static_data.py`
- `python -m pytest -q` *(fails: No module named pytest)*