### PR TITLE
Fix README whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ env = retro.make(game="PokemonYellow-GB")
 You can then start training with (use `--seed` for deterministic results):
 
 ```bash
-python train_agent.py --retro-dir integrations \
-    --goals data/first_three_gyms.json \
-    --config configs/default.json \
+python train_agent.py --retro-dir integrations\
+    --goals data/first_three_gyms.json\
+    --config configs/default.json\
     --seed 42
 
 If you already imported the ROM into `~/.retro`, the `--retro-dir` argument can


### PR DESCRIPTION
## Summary
- remove superfluous spaces before the line continuation character in the training command block
- verify no trailing whitespace remains

## Testing
- `grep -n $'[ \t]$' -R . --exclude-dir=.git`