### PR TITLE
Consolidate reward checking logic

### DIFF
--- a/tests/test_rewarder.py
+++ b/tests/test_rewarder.py
@@ -1,6 +1,6 @@
 import unittest
 
-from rewarder import predicate_from_goal, Rewarder
+from rewarder import Rewarder
 from poke_rewards import MAP_ID_ADDR, BADGE_FLAGS_ADDR
 
 
@@ -10,24 +10,6 @@ def make_mem(map_id: int = 0, badge_flags: int = 0, size: int = 0xE000) -> bytea
     mem[BADGE_FLAGS_ADDR] = badge_flags
     return mem
 
-
-class TestPredicateFromGoal(unittest.TestCase):
-    def test_map_goal_predicate(self):
-        goal = {"id": "reach_city", "type": "map", "target_id": 1}
-        pred = predicate_from_goal(goal)
-        prev = make_mem(map_id=0)
-        curr = make_mem(map_id=1)
-        self.assertTrue(pred(prev, curr))
-        # no change should be False
-        self.assertFalse(pred(curr, curr))
-
-    def test_event_goal_predicate(self):
-        goal = {"id": "defeat_brock", "type": "event", "target_id": 0}
-        pred = predicate_from_goal(goal)
-        prev = make_mem(badge_flags=0)
-        curr = make_mem(badge_flags=0b00000001)
-        self.assertTrue(pred(prev, curr))
-        self.assertFalse(pred(curr, curr))
 
 
 class TestRewarderCompute(unittest.TestCase):


### PR DESCRIPTION
## Summary
- remove predicate-based reward checks
- implement `Rewarder` using existing `check_goals`
- update unit tests for new implementation

## Testing
- `python -m unittest discover -v tests`