### PR TITLE
Introduce structured GoalDict type

### DIFF
--- a/poke_rewards.py
+++ b/poke_rewards.py
@@ -2,7 +2,7 @@
 
 from typing import Iterable, List, Tuple
 
-from types_shared import Goal
+from types_shared import GoalDict
 
 # Memory addresses based on community documentation
 # Address of the current map ID within WRAM
@@ -67,7 +67,7 @@ def _event_flag_set(prev: bytes, curr: bytes, flag_index: int) -> bool:
 def check_goals(
     prev_mem: bytes,
     curr_mem: bytes,
-    goals: Iterable[Goal],
+    goals: Iterable[GoalDict],
 ) -> List[Tuple[str, float]]:
     """Check memory snapshots for goal completion.
 
@@ -76,9 +76,9 @@ def check_goals(
     prev_mem, curr_mem
         Consecutive WRAM snapshots as ``bytes`` or ``bytearray`` objects.
     goals
-        Iterable of goal dictionaries.  Each goal must contain ``id`` (str),
-        ``type`` (``"map"`` or ``"event"``), and ``target_id`` (int).  Goals may
-        optionally include ``reward`` (float).
+        Iterable of goal dictionaries. Each goal must contain ``id`` (str),
+        ``type`` (``"map"`` or ``"event"``), ``target_id`` (int), ``reward``
+        (float) and ``prerequisites`` (list of str).
 
     Returns
     -------

--- a/ppo.py
+++ b/ppo.py
@@ -12,7 +12,7 @@ import json
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Sequence, Tuple, Set
 
-from types_shared import Goal
+from types_shared import GoalDict
 
 try:
     import yaml  # type: ignore
@@ -48,7 +48,7 @@ def load_config(path: str) -> Dict[str, Any]:
 class Curriculum:
     """Manage goal progression during training."""
 
-    def __init__(self, goals: Sequence[Goal], threshold: float = 0.8) -> None:
+    def __init__(self, goals: Sequence[GoalDict], threshold: float = 0.8) -> None:
         self.goals = {g["id"]: g for g in goals}
         self.threshold = threshold
         self.stats: Dict[str, Dict[str, int]] = {
@@ -56,7 +56,7 @@ class Curriculum:
         }
         self.active: Set[str] = {g["id"] for g in goals if not g.get("prerequisites")}
 
-    def active_goals(self) -> List[Goal]:
+    def active_goals(self) -> List[GoalDict]:
         return [self.goals[g] for g in self.active]
 
     def record_episode(self, triggered: Iterable[str]) -> None:

--- a/rewarder.py
+++ b/rewarder.py
@@ -2,7 +2,7 @@
 
 from typing import Callable, Iterable, List, Tuple
 
-from types_shared import Goal
+from types_shared import GoalDict
 
 from poke_rewards import (
     _map_changed,
@@ -14,7 +14,7 @@ from poke_rewards import (
 Predicate = Callable[[bytes, bytes], bool]
 
 
-def predicate_from_goal(goal: Goal) -> Predicate:
+def predicate_from_goal(goal: GoalDict) -> Predicate:
     """Create a predicate function for a single goal."""
     gtype = goal.get("type")
     target_id = int(goal.get("target_id", 0))
@@ -40,7 +40,7 @@ def predicate_from_goal(goal: Goal) -> Predicate:
 class Rewarder:
     """Compute shaped rewards from WRAM snapshots."""
 
-    def __init__(self, goals: Iterable[Goal]):
+    def __init__(self, goals: Iterable[GoalDict]):
         self._entries: List[Tuple[str, Predicate, float]] = []
         for goal in goals:
             pred = predicate_from_goal(goal)

--- a/tests/test_poke_rewards.py
+++ b/tests/test_poke_rewards.py
@@ -28,7 +28,13 @@ class TestPokeRewards(unittest.TestCase):
         curr = make_mem(map_id=1)
 
         goals = [
-            {"id": "reach_viridian_city", "type": "map", "target_id": 1, "reward": 1.0}
+            {
+                "id": "reach_viridian_city",
+                "type": "map",
+                "target_id": 1,
+                "reward": 1.0,
+                "prerequisites": [],
+            }
         ]
 
         triggered = check_goals(prev, curr, goals)
@@ -39,7 +45,13 @@ class TestPokeRewards(unittest.TestCase):
         curr = make_mem(badge_flags=0b00000001)
 
         goals = [
-            {"id": "defeat_brock", "type": "event", "target_id": 0, "reward": 5.0}
+            {
+                "id": "defeat_brock",
+                "type": "event",
+                "target_id": 0,
+                "reward": 5.0,
+                "prerequisites": [],
+            }
         ]
 
         triggered = check_goals(prev, curr, goals)
@@ -50,8 +62,20 @@ class TestPokeRewards(unittest.TestCase):
         curr = make_mem(map_id=1, badge_flags=0b00000001)
 
         goals = [
-            {"id": "reach_viridian_city", "type": "map", "target_id": 1, "reward": 1.0},
-            {"id": "defeat_brock", "type": "event", "target_id": 0, "reward": 5.0},
+            {
+                "id": "reach_viridian_city",
+                "type": "map",
+                "target_id": 1,
+                "reward": 1.0,
+                "prerequisites": [],
+            },
+            {
+                "id": "defeat_brock",
+                "type": "event",
+                "target_id": 0,
+                "reward": 5.0,
+                "prerequisites": [],
+            },
         ]
 
         triggered = check_goals(prev, curr, goals)
@@ -62,8 +86,20 @@ class TestPokeRewards(unittest.TestCase):
         curr = make_mem(map_id=1, badge_flags=0b00000001)
 
         goals = [
-            {"id": "reach_viridian_city", "type": "map", "target_id": 1, "reward": 1.0},
-            {"id": "defeat_brock", "type": "event", "target_id": 0, "reward": 5.0},
+            {
+                "id": "reach_viridian_city",
+                "type": "map",
+                "target_id": 1,
+                "reward": 1.0,
+                "prerequisites": [],
+            },
+            {
+                "id": "defeat_brock",
+                "type": "event",
+                "target_id": 0,
+                "reward": 5.0,
+                "prerequisites": [],
+            },
         ]
 
         triggered = check_goals(prev, curr, goals)

--- a/tests/test_rewarder.py
+++ b/tests/test_rewarder.py
@@ -13,7 +13,13 @@ def make_mem(map_id: int = 0, badge_flags: int = 0, size: int = 0xE000) -> bytea
 
 class TestPredicateFromGoal(unittest.TestCase):
     def test_map_goal_predicate(self):
-        goal = {"id": "reach_city", "type": "map", "target_id": 1}
+        goal = {
+            "id": "reach_city",
+            "type": "map",
+            "target_id": 1,
+            "reward": 1.0,
+            "prerequisites": [],
+        }
         pred = predicate_from_goal(goal)
         prev = make_mem(map_id=0)
         curr = make_mem(map_id=1)
@@ -22,7 +28,13 @@ class TestPredicateFromGoal(unittest.TestCase):
         self.assertFalse(pred(curr, curr))
 
     def test_event_goal_predicate(self):
-        goal = {"id": "defeat_brock", "type": "event", "target_id": 0}
+        goal = {
+            "id": "defeat_brock",
+            "type": "event",
+            "target_id": 0,
+            "reward": 1.0,
+            "prerequisites": [],
+        }
         pred = predicate_from_goal(goal)
         prev = make_mem(badge_flags=0)
         curr = make_mem(badge_flags=0b00000001)
@@ -33,8 +45,20 @@ class TestPredicateFromGoal(unittest.TestCase):
 class TestRewarderCompute(unittest.TestCase):
     def test_compute_returns_sum_and_ids(self):
         goals = [
-            {"id": "reach_city", "type": "map", "target_id": 1, "reward": 1.0},
-            {"id": "defeat_brock", "type": "event", "target_id": 0, "reward": 5.0},
+            {
+                "id": "reach_city",
+                "type": "map",
+                "target_id": 1,
+                "reward": 1.0,
+                "prerequisites": [],
+            },
+            {
+                "id": "defeat_brock",
+                "type": "event",
+                "target_id": 0,
+                "reward": 5.0,
+                "prerequisites": [],
+            },
         ]
         rew = Rewarder(goals)
         prev = make_mem(map_id=0, badge_flags=0)

--- a/types_shared.py
+++ b/types_shared.py
@@ -1,6 +1,14 @@
 """Common type aliases for PokeYellowAI modules."""
 
-from typing import Dict
+from typing import List, TypedDict
 
-# Mapping of goal attributes used across the project
-Goal = Dict[str, object]
+
+class GoalDict(TypedDict):
+    """Structured representation of a training goal."""
+
+    id: str
+    type: str
+    target_id: int
+    reward: float
+    prerequisites: List[str]
+


### PR DESCRIPTION
## Summary
- replace `Goal` alias with `GoalDict` TypedDict
- update reward modules to use new typed structure
- adjust Curriculum to expect `GoalDict`
- update unit tests for new required goal keys

## Testing
- `python -m unittest discover tests -v`