### PR TITLE
Fix Rewarder compute logic

### DIFF
--- a/rewarder.py
+++ b/rewarder.py
@@ -1,6 +1,6 @@
 """Goal-based reward computation utilities."""
 
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Tuple, Callable
 
 from types_shared import GoalDict
 
@@ -50,7 +50,12 @@ class Rewarder:
         self, prev_mem: bytes, curr_mem: bytes, env_reward: float = 0.0
     ) -> Tuple[float, List[str]]:
         """Return total reward and IDs of triggered goals."""
-        triggered_pairs = check_goals(prev_mem, curr_mem, self._goals)
-        total = env_reward + sum(rew for _, rew in triggered_pairs)
-        triggered_ids = [gid for gid, _ in triggered_pairs]
+        total = env_reward
+        triggered_ids: List[str] = []
+
+        for goal_id, predicate, reward in self._entries:
+            if predicate(prev_mem, curr_mem):
+                total += reward
+                triggered_ids.append(goal_id)
+
         return total, triggered_ids

--- a/tests/test_rewarder.py
+++ b/tests/test_rewarder.py
@@ -1,6 +1,6 @@
 import unittest
 
-from rewarder import Rewarder
+from rewarder import Rewarder, predicate_from_goal
 from poke_rewards import MAP_ID_ADDR, BADGE_FLAGS_ADDR
 
 


### PR DESCRIPTION
## Summary
- calculate rewards directly from entries in `Rewarder.compute`
- expose `predicate_from_goal` to unit tests

## Testing
- `python3 -m unittest discover -v tests`