### PR TITLE
Fix README fenced block

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ python train_agent.py --retro-dir integrations\
     --config configs/default.json\
     --seed 42\
     --device cuda
+```
 
 If you already imported the ROM into `~/.retro`, the `--retro-dir` argument can
 be omitted. You may supply a different goals file using `--goals` and a


### PR DESCRIPTION
## Summary
- close fenced code block for training command in README

## Testing
- `python -m unittest discover tests` *(fails: NameError in rewarder.py)*