### PR TITLE
Use NotRequired for optional goal fields

### DIFF
--- a/poke_rewards.py
+++ b/poke_rewards.py
@@ -77,8 +77,8 @@ def check_goals(
         Consecutive WRAM snapshots as ``bytes`` or ``bytearray`` objects.
     goals
         Iterable of goal dictionaries. Each goal must contain ``id`` (str),
-        ``type`` (``"map"`` or ``"event"``), ``target_id`` (int), ``reward``
-        (float) and ``prerequisites`` (list of str).
+        ``type`` (``"map"`` or ``"event"``) and ``target_id`` (int). Optional
+        ``reward`` values and ``prerequisites`` lists may be provided.
 
     Returns
     -------

--- a/rewarder.py
+++ b/rewarder.py
@@ -1,10 +1,11 @@
 """Goal-based reward computation utilities."""
 
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Tuple, Callable
 
 from types_shared import GoalDict
 
 from poke_rewards import (
+    check_goals,
     _map_changed,
     _badge_bit_set,
     _event_flag_set,
@@ -40,11 +41,7 @@ class Rewarder:
     """Compute shaped rewards from WRAM snapshots."""
 
     def __init__(self, goals: Iterable[GoalDict]):
-        self._entries: List[Tuple[str, Predicate, float]] = []
-        for goal in goals:
-            pred = predicate_from_goal(goal)
-            reward = float(goal.get("reward", 1.0))
-            self._entries.append((goal["id"], pred, reward))
+        self._goals = list(goals)
 
     def compute(
         self, prev_mem: bytes, curr_mem: bytes, env_reward: float = 0.0

--- a/tests/test_poke_rewards.py
+++ b/tests/test_poke_rewards.py
@@ -57,6 +57,22 @@ class TestPokeRewards(unittest.TestCase):
         triggered = check_goals(prev, curr, goals)
         self.assertEqual(triggered, [("defeat_brock", 5.0)])
 
+    def test_default_reward_and_prerequisites(self):
+        """Goals without optional fields should use default values."""
+        prev = make_mem(map_id=0)
+        curr = make_mem(map_id=1)
+
+        goals = [
+            {
+                "id": "reach_viridian_city",
+                "type": "map",
+                "target_id": 1,
+            }
+        ]
+
+        triggered = check_goals(prev, curr, goals)
+        self.assertEqual(triggered, [("reach_viridian_city", 1.0)])
+
     def test_no_trigger_when_values_unchanged(self):
         prev = make_mem(map_id=1, badge_flags=0b00000001)
         curr = make_mem(map_id=1, badge_flags=0b00000001)

--- a/tests/test_rewarder.py
+++ b/tests/test_rewarder.py
@@ -1,6 +1,6 @@
 import unittest
 
-from rewarder import Rewarder
+from rewarder import Rewarder, predicate_from_goal
 from poke_rewards import MAP_ID_ADDR, BADGE_FLAGS_ADDR
 
 
@@ -64,6 +64,18 @@ class TestRewarderCompute(unittest.TestCase):
         total, triggered = rew.compute(prev, curr, env_reward=0.5)
         self.assertAlmostEqual(total, 6.5)
         self.assertEqual(set(triggered), {"reach_city", "defeat_brock"})
+
+    def test_compute_with_defaults(self):
+        """Rewarder should handle goals missing optional fields."""
+        goals = [
+            {"id": "reach_city", "type": "map", "target_id": 1},
+        ]
+        rew = Rewarder(goals)
+        prev = make_mem(map_id=0)
+        curr = make_mem(map_id=1)
+        total, triggered = rew.compute(prev, curr)
+        self.assertAlmostEqual(total, 1.0)
+        self.assertEqual(triggered, ["reach_city"])
 
 
 if __name__ == "__main__":

--- a/types_shared.py
+++ b/types_shared.py
@@ -2,6 +2,11 @@
 
 from typing import List, TypedDict
 
+try:  # Python >=3.11
+    from typing import NotRequired
+except ImportError:  # pragma: no cover - fallback for older versions
+    from typing_extensions import NotRequired
+
 
 class GoalDict(TypedDict):
     """Structured representation of a training goal."""
@@ -9,6 +14,6 @@ class GoalDict(TypedDict):
     id: str
     type: str
     target_id: int
-    reward: float
-    prerequisites: List[str]
+    reward: NotRequired[float]
+    prerequisites: NotRequired[List[str]]
 


### PR DESCRIPTION
## Summary
- make `reward` and `prerequisites` optional in `GoalDict`
- fix rewarder utility bugs and import issues
- document optional goal fields in `check_goals`
- add tests covering missing optional fields

## Testing
- `python -m unittest discover -s tests -q`