### PR TITLE
Add Python bytecode ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.gbc
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Summary
- ignore Python bytecode files so they don't pollute the repo

## Testing
- `git ls-files | grep __pycache__ | wc -l`
- `find . -type d -name '__pycache__' | wc -l`