### PR TITLE
Fix YAML import exception handling

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -16,7 +16,7 @@ from types_shared import GoalDict
 
 try:
     import yaml  # type: ignore
-except Exception:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     yaml = None
 
 try:  # Optional heavy deps


### PR DESCRIPTION
## Summary
- use `ImportError` instead of `Exception` when importing optional YAML

## Testing
- `python -m unittest discover -s tests`